### PR TITLE
Fix error that skips primary keys with a documentation

### DIFF
--- a/src/main/scala/com/datamountaineer/streamreactor/connect/rowkeys/RowKeyBuilderString.scala
+++ b/src/main/scala/com/datamountaineer/streamreactor/connect/rowkeys/RowKeyBuilderString.scala
@@ -64,16 +64,17 @@ class StringSinkRecordKeyBuilder extends StringKeyBuilder {
   */
 case class StringStructFieldsStringKeyBuilder(keys: Seq[String],
                                               keyDelimiter: String = ".") extends StringKeyBuilder {
-  private val availableSchemas = Set(
-    Schema.BOOLEAN_SCHEMA, Schema.OPTIONAL_BOOLEAN_SCHEMA,
-    Schema.BYTES_SCHEMA, Schema.OPTIONAL_BYTES_SCHEMA,
-    Schema.FLOAT32_SCHEMA, Schema.OPTIONAL_FLOAT32_SCHEMA,
-    Schema.FLOAT64_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA,
-    Schema.INT8_SCHEMA, Schema.OPTIONAL_INT8_SCHEMA,
-    Schema.INT16_SCHEMA, Schema.OPTIONAL_INT16_SCHEMA,
-    Schema.INT32_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA,
-    Schema.INT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA,
-    Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
+  private val availableSchemaTypes = Set(
+    Schema.Type.BOOLEAN,
+    Schema.Type.BYTES,
+    Schema.Type.FLOAT32,
+    Schema.Type.FLOAT64,
+    Schema.Type.INT8,
+    Schema.Type.INT16,
+    Schema.Type.INT32,
+    Schema.Type.INT64,
+    Schema.Type.STRING
+  )
 
   require(keys.nonEmpty, "Invalid keys provided")
 
@@ -94,8 +95,9 @@ case class StringStructFieldsStringKeyBuilder(keys: Seq[String],
     keys.flatMap { case key =>
       val field = schema.field(key)
       val value = struct.get(field)
+
       require(value != null, s"$key field value is null. Non null value is required for the fileds creating the Hbase row key")
-      if (availableSchemas.contains(field.schema())) Some(value.toString)
+      if (availableSchemaTypes.contains(field.schema().`type`())) Some(value.toString)
       else None
     }.mkString(keyDelimiter)
   }

--- a/src/test/scala/com/datamountaineer/streamreactor/connect/sink/StringStructFieldsStringKeyBuilderTest.scala
+++ b/src/test/scala/com/datamountaineer/streamreactor/connect/sink/StringStructFieldsStringKeyBuilderTest.scala
@@ -50,6 +50,19 @@ class StringStructFieldsStringKeyBuilderTest extends WordSpec with Matchers {
       StringStructFieldsStringKeyBuilder(Seq("firstName")).build(sinkRecord) shouldBe "Alex"
     }
 
+    "create the row key based on one single field with doc in the struct" in {
+      val firstNameSchema = SchemaBuilder.`type`(Schema.Type.STRING).doc("first name")
+      val schema = SchemaBuilder.struct().name("com.example.Person")
+        .field("firstName", firstNameSchema)
+        .field("age", Schema.INT32_SCHEMA)
+        .field("threshold", Schema.OPTIONAL_FLOAT64_SCHEMA).build()
+
+      val struct = new Struct(schema).put("firstName", "Alex").put("age", 30)
+
+      val sinkRecord = new SinkRecord("sometopic", 1, null, null, schema, struct, 1)
+      StringStructFieldsStringKeyBuilder(Seq("firstName")).build(sinkRecord) shouldBe "Alex"
+    }
+
     "create the row key based on more thant one field in the struct" in {
       val schema = SchemaBuilder.struct().name("com.example.Person")
         .field("firstName", Schema.STRING_SCHEMA)


### PR DESCRIPTION
We discovered this error in the redis connector, but it probably applies to other connectors as well.

**Problem**
If the PK field has a documentation on the schema, then the field is not added to the primary keys, and thus all records will have an empty string for key.

**Cause**
The code verifies if the primary key field's schema is one of the basic schema types, but instead of verifying only the schema types, it checks the equality of all fields of the schema (including the documentation field among others).

The unit test added demonstrates this behavior: it fails without the fix, but passes otherwise.
